### PR TITLE
Update link to video

### DIFF
--- a/continuous-integration/tfs-2010.md
+++ b/continuous-integration/tfs-2010.md
@@ -21,7 +21,7 @@ It breaks you free from tedious configuration of environment variables and provi
 
 > **Note**
 >
-> You could also check the step-by-step video about [How to configure JustMock test execution within TFS code activity workflow](https://tv.telerik.com/watch/justmock/how-to-configure-justmock-test-execution-within-tfs-code-activity-workflow).
+> You could also check the step-by-step video about [How to configure JustMock test execution within TFS code activity workflow](https://www.telerik.com/videos/justmock/how-to-configure-justmock-test-execution-within-tfs-code-activity-workflow).
           
 
 ## Configuration Steps


### PR DESCRIPTION
The link to the video "How to configure JustMock test execution within TFS code activity workflow." was broken and it was updated with the correct link.