### PR TITLE
Removing the tip when using a slug

### DIFF
--- a/getting-started/using-telerik-justmock-in-your-test-project.md
+++ b/getting-started/using-telerik-justmock-in-your-test-project.md
@@ -30,7 +30,7 @@ This topic demonstrates how to use __Telerik® JustMock__ in a new test project 
 
 1. Using the default *JustMock Test Project* template, you can start writing JustMock tests right away. 
 	
-	>tip See an example how to use JustMock in [JustMock API Basics]({%slug justmock/basic-usage/mock%})
+	> See an example how to use JustMock in [JustMock API Basics]({%slug justmock/basic-usage/mock%})
 
 ## Add JustMock to a Test Project
 

--- a/getting-started/using-telerik-justmock-in-your-test-project.md
+++ b/getting-started/using-telerik-justmock-in-your-test-project.md
@@ -30,7 +30,7 @@ This topic demonstrates how to use __Telerik® JustMock__ in a new test project 
 
 1. Using the default *JustMock Test Project* template, you can start writing JustMock tests right away. 
 	
-	>tip See an example how to use JustMock in [JustMock API Basics]({%slug justmock/basic-usage/mock%}) 
+	>tip See an example how to use JustMock in [JustMock API Basics]({%slug justmock/basic-usage/mock%})
 
 ## Add JustMock to a Test Project
 


### PR DESCRIPTION
Currently, the tip is breaking the slug link. I am removing the tip until a fix is provided.