### PR TITLE
fix: add Automocking examples to ReturnsAsync article

### DIFF
--- a/basic-usage/mock/returns-async.md
+++ b/basic-usage/mock/returns-async.md
@@ -333,7 +333,6 @@ In **Example 6**, we extend this by explicitly specifying the return type, showi
 
 {{region ReturnAsync#TestTaskAutomockingAsyncResultWithIntParameter}}
 
-	[TestMethod]
  	<TestMethod>
 	Public Async Function TestTaskAutomockingAsyncResultWithIntParameter() As Task
     	' Arange


### PR DESCRIPTION
- add new paragraph about MockingContainer with ReturnsAsync
- add basic example
- add example with explicit return value

closes telerik/MATTeam#787