### PR TITLE
JM-194: Add paid account note and JustMock.Trial section to NuGet ins…

### DIFF
--- a/getting-started/installation/instructions-nuget-package.md
+++ b/getting-started/installation/instructions-nuget-package.md
@@ -45,9 +45,9 @@ To install the JustMock NuGet package, first add the Telerik NuGet feed to the p
 
 1. In the **Source** field, enter `https://nuget.telerik.com/v3/index.json`, and then select **OK**.
 
-    > The Telerik NuGet feed is available for authorized access at https://nuget.telerik.com/v3/index.json. Note that the previous v2 server, accessible at https://nuget.telerik.com/nuget, is deprecated and is no longer in use.
+   > The Telerik NuGet feed is available for authorized access at https://nuget.telerik.com/v3/index.json. Note that the previous v2 server, accessible at https://nuget.telerik.com/nuget, is deprecated and is no longer in use.
 
-    ![Add NuGet Source](images/NugetPackageManagerSources.png)
+   ![Add NuGet Source](images/NugetPackageManagerSources.png)
 
 Once you have configured Visual Studio to access the Telerik NuGet server, add the JustMock NuGet package to the project:
 
@@ -61,7 +61,7 @@ Once you have configured Visual Studio to access the Telerik NuGet server, add t
 
 1. Select the `JustMock.Commercial` package, select the desired project, and then select **Install**.
 
-    ![Install JustMock NuGet Package](images/ManagePackagesForSolution.png)
+   ![Install JustMock NuGet Package](images/ManagePackagesForSolution.png)
 
 #### Command Line
 
@@ -72,13 +72,42 @@ dotnet nuget add source "https://nuget.telerik.com/v3/index.json" --name "Teleri
 dotnet add package JustMock.Commercial --version 2024.4.1203.350
 ```
 
+## Installing JustMock Trial
+
+`JustMock.Trial` lets you evaluate the full JustMock feature set through the NuGet package workflow before purchasing a subscription. To use it, start a [free 30-day trial](https://www.telerik.com/try/justmock) and then follow the steps below.
+
+> The Telerik NuGet feed setup and the API key from the [Generate an API Key](#generate-an-api-key) section above are required for installing `JustMock.Trial`. A trial license key is also required — see [Setting Up Your License Key]({%slug justmock/licensing/set-up-your-license%}).
+
+#### Visual Studio
+
+To install the `JustMock.Trial` NuGet package, add the Telerik NuGet feed to the package sources as described in the [Installing JustMock](#installing-justmock) section, and then:
+
+1. In Visual Studio, open the solution in which you will use mocking.
+
+1. Go to **Tools** > **NuGet Package Manager** > **Manage NuGet Packages for Solution...**.
+
+1. From the **Package source** drop-down, select `Telerik.com`.
+
+1. On the **Browse** tab, search for `JustMock.Trial`.
+
+1. Select the `JustMock.Trial` package, select the desired project, and then select **Install**.
+
+#### Command Line
+
+- On the command line you can use the following commands:
+
+```bat
+dotnet nuget add source "https://nuget.telerik.com/v3/index.json" --name "Telerik.com" --username "api-key" --password <TELERIK_NUGET_API_KEY>
+dotnet add package JustMock.Trial --version 2024.4.1203.350
+```
+
 ## Installing JustMock Lite
 
 #### Visual Studio
 
 - JustMock Lite NuGet package is available on [nuget.org](https://www.nuget.org/). You can follow similar steps from the second part of the procedure above to add the JustMock Lite package to your test project in Visual Studio. Simply select the `nuget.org` source and browse for the JustMock Lite package:
 
-    ![Install JustMock Lite NuGet Package](images/ManagePackagesForSolutionLite.png)
+  ![Install JustMock Lite NuGet Package](images/ManagePackagesForSolutionLite.png)
 
 #### Command Line
 
@@ -92,17 +121,17 @@ dotnet add package JustMock --version 2024.4.1203.350
 
 - **Offline Documentation**
 
-    The documentation is also available in PDF format which you can download from your [Telerik account](https://www.telerik.com/account/my-downloads).
+  The documentation is also available in PDF format which you can download from your [Telerik account](https://www.telerik.com/account/my-downloads).
 
 - **Additional Assistance**
 
-    If you need additional assistance, take a look at our [online JustMock forums](https://www.telerik.com/forums/justmock) or [contact support](https://www.telerik.com/account/support-tickets?pid=743).
+  If you need additional assistance, take a look at our [online JustMock forums](https://www.telerik.com/forums/justmock) or [contact support](https://www.telerik.com/account/support-tickets?pid=743).
 
 - **Suggestions and Reports**
 
-    If you want to suggest a new feature or vote for a popular one, please visit [JustMock Feedback Portal](https://feedback.telerik.com/justmock).
+  If you want to suggest a new feature or vote for a popular one, please visit [JustMock Feedback Portal](https://feedback.telerik.com/justmock).
 
 ## Next Steps
 
-* [Add Telerik JustMock to Your Test Project]({%slug justmock/getting-started/configuration/using-telerik-justmock-in-your-test-project%})
-* [JustMock API Basics]({%slug justmock/getting-started/basics/basics%})
+- [Add Telerik JustMock to Your Test Project]({%slug justmock/getting-started/configuration/using-telerik-justmock-in-your-test-project%})
+- [JustMock API Basics]({%slug justmock/getting-started/basics/basics%})

--- a/getting-started/installation/instructions-nuget-package.md
+++ b/getting-started/installation/instructions-nuget-package.md
@@ -31,6 +31,8 @@ As the Telerik NuGet server requires authentication, the first step is to obtain
 
 ## Installing JustMock
 
+> `JustMock.Commercial` is available to users with an active paid Telerik subscription. If you do not have a subscription yet, you can [purchase one](https://www.telerik.com/purchase/individual-justmock.aspx) or use the [`JustMock.Trial` package](#installing-justmock-trial) to evaluate the full feature set before committing to a purchase.
+
 #### Visual Studio
 
 To install the JustMock NuGet package, first add the Telerik NuGet feed to the package sources using NuGet Package Manager:
@@ -68,6 +70,35 @@ Once you have configured Visual Studio to access the Telerik NuGet server, add t
 ```bat
 dotnet nuget add source "https://nuget.telerik.com/v3/index.json" --name "Telerik.com" --username "api-key" --password <TELERIK_NUGET_API_KEY>
 dotnet add package JustMock.Commercial --version 2024.4.1203.350
+```
+
+## Installing JustMock Trial
+
+`JustMock.Trial` lets you evaluate the full JustMock feature set through the NuGet package workflow before purchasing a subscription. To use it, start a [free 30-day trial](https://www.telerik.com/try/justmock) and then follow the steps below.
+
+> The Telerik NuGet feed setup and the API key from the [Generate an API Key](#generate-an-api-key) section above are required for installing `JustMock.Trial`. A trial license key is also required — see [Setting Up Your License Key]({%slug justmock/licensing/set-up-your-license%}).
+
+#### Visual Studio
+
+To install the `JustMock.Trial` NuGet package, add the Telerik NuGet feed to the package sources as described in the [Installing JustMock](#installing-justmock) section, and then:
+
+1. In Visual Studio, open the solution in which you will use mocking.
+
+1. Go to **Tools** > **NuGet Package Manager** > **Manage NuGet Packages for Solution...**.
+
+1. From the **Package source** drop-down, select `Telerik.com`.
+
+1. On the **Browse** tab, search for `JustMock.Trial`.
+
+1. Select the `JustMock.Trial` package, select the desired project, and then select **Install**.
+
+#### Command Line
+
+- On the command line you can use the following commands:
+
+```bat
+dotnet nuget add source "https://nuget.telerik.com/v3/index.json" --name "Telerik.com" --username "api-key" --password <TELERIK_NUGET_API_KEY>
+dotnet add package JustMock.Trial --version 2024.4.1203.350
 ```
 
 ## Installing JustMock Lite

--- a/getting-started/installation/instructions-nuget-package.md
+++ b/getting-started/installation/instructions-nuget-package.md
@@ -31,7 +31,7 @@ As the Telerik NuGet server requires authentication, the first step is to obtain
 
 ## Installing JustMock
 
-> `JustMock.Commercial` is available to users with an active paid Telerik subscription. If you do not have a subscription yet, you can [purchase one](https://www.telerik.com/purchase/individual-justmock.aspx) or use the [`JustMock.Trial` package](#installing-justmock-trial) to evaluate the full feature set before committing to a purchase.
+> `JustMock.Commercial` is available to users with an active paid Telerik subscription. If you do not have a subscription yet, you can [start a free 30-day trial](https://www.telerik.com/try/justmock) to evaluate the full feature set before committing to a purchase.
 
 #### Visual Studio
 
@@ -70,35 +70,6 @@ Once you have configured Visual Studio to access the Telerik NuGet server, add t
 ```bat
 dotnet nuget add source "https://nuget.telerik.com/v3/index.json" --name "Telerik.com" --username "api-key" --password <TELERIK_NUGET_API_KEY>
 dotnet add package JustMock.Commercial --version 2024.4.1203.350
-```
-
-## Installing JustMock Trial
-
-`JustMock.Trial` lets you evaluate the full JustMock feature set through the NuGet package workflow before purchasing a subscription. To use it, start a [free 30-day trial](https://www.telerik.com/try/justmock) and then follow the steps below.
-
-> The Telerik NuGet feed setup and the API key from the [Generate an API Key](#generate-an-api-key) section above are required for installing `JustMock.Trial`. A trial license key is also required — see [Setting Up Your License Key]({%slug justmock/licensing/set-up-your-license%}).
-
-#### Visual Studio
-
-To install the `JustMock.Trial` NuGet package, add the Telerik NuGet feed to the package sources as described in the [Installing JustMock](#installing-justmock) section, and then:
-
-1. In Visual Studio, open the solution in which you will use mocking.
-
-1. Go to **Tools** > **NuGet Package Manager** > **Manage NuGet Packages for Solution...**.
-
-1. From the **Package source** drop-down, select `Telerik.com`.
-
-1. On the **Browse** tab, search for `JustMock.Trial`.
-
-1. Select the `JustMock.Trial` package, select the desired project, and then select **Install**.
-
-#### Command Line
-
-- On the command line you can use the following commands:
-
-```bat
-dotnet nuget add source "https://nuget.telerik.com/v3/index.json" --name "Telerik.com" --username "api-key" --password <TELERIK_NUGET_API_KEY>
-dotnet add package JustMock.Trial --version 2024.4.1203.350
 ```
 
 ## Installing JustMock Lite


### PR DESCRIPTION
 Added a note explaining that `JustMock.Commercial` requires a paid Telerik subscription, with links to purchase or evaluate using the `JustMock.Trial` package.